### PR TITLE
fix: fix ensemble load error

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,6 @@ coverage:
   range: 80..100
   round: down
   precision: 2
+  status:
+    project: off
+    patch: off

--- a/pydiffuser/tracer/ensemble.py
+++ b/pydiffuser/tracer/ensemble.py
@@ -193,7 +193,7 @@ class Ensemble(Component, OrderedDict):  # type: ignore[type-arg]
     def __reduce__(self) -> Tuple[Any, ...]:
         info = super().__reduce__()
         args = self.dt
-        new_info = (self.__class__, args, *info[2:])
+        new_info = (self.__class__, (args,), *info[2:])
         return new_info
 
     def to_npy(self, npy_path: PathType) -> None:

--- a/pydiffuser/utils/config.py
+++ b/pydiffuser/utils/config.py
@@ -49,9 +49,16 @@ class BaseDiffusionConfig(abc.ABC):
             json.dump(info, f, indent=4)
 
     def to_dataclass(self) -> object:
-        info = copy.deepcopy(vars(self))
+        info = self.to_dict()
         obj = make_dataclass(self.__class__.__name__, info.keys())
         return obj(**info)
 
+    def to_dict(self) -> Dict[str, Any]:
+        info = copy.deepcopy(vars(self))
+        return info
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name})"
+
+    def __contains__(self, param: str) -> bool:
+        return param in self.to_dict()


### PR DESCRIPTION
To make `Ensemble` picklable, the second element of `__reduce__` should be a tuple.