### PR TITLE
feat: alter the simulation strategy for CTRW

### DIFF
--- a/pydiffuser/__init__.py
+++ b/pydiffuser/__init__.py
@@ -18,7 +18,7 @@ from .models import (
     VicsekModelConfig,
 )
 from .tracer import Ensemble, Trajectory
-from .utils import load, save
+from .utils import load, random, save
 
 __all__ = [
     "__version__",
@@ -41,5 +41,6 @@ __all__ = [
     "Ensemble",
     "Trajectory",
     "load",
+    "random",
     "save",
 ]

--- a/pydiffuser/models/bm.py
+++ b/pydiffuser/models/bm.py
@@ -1,10 +1,9 @@
 import jax.numpy as jnp
 from scipy.stats import norm
 
-from pydiffuser.logger import logger
 from pydiffuser.models.core import BaseDiffusion
 from pydiffuser.tracer import Ensemble, Trajectory
-from pydiffuser.utils import BaseDiffusionConfig, jitted
+from pydiffuser.utils import BaseDiffusionConfig, helpers, jitted
 
 
 class BrownianMotionConfig(BaseDiffusionConfig):
@@ -49,14 +48,10 @@ class BrownianMotion(BaseDiffusion):
         ens.update_microstate(microstate=x)
         return ens
 
+    @helpers.deprecated
     def create(
         self, realization: int, length: int, dimension: int, dt: float
     ) -> Ensemble:
-        logger.warning(
-            "The method `create` is deprecated. "
-            "Please use `generate` instead, which utilizes batch calculation.",
-            stacklevel=2,
-        )
         import numpy as np
 
         ens = Ensemble(dt=dt)

--- a/pydiffuser/models/levy.py
+++ b/pydiffuser/models/levy.py
@@ -1,13 +1,18 @@
 from functools import partial
+from typing import Dict
 
+import jax
 import jax.numpy as jnp
-from jax import Array
+from jax import Array, vmap
+from jax.random import PRNGKey
+from numpy.random import randint
 from scipy.stats import pareto
 
 from pydiffuser.models.core import (
     ContinuousTimeRandomWalk,
     ContinuousTimeRandomWalkConfig,
 )
+from pydiffuser.tracer import Ensemble
 from pydiffuser.typing import ConstType
 from pydiffuser.utils import jitted
 
@@ -21,7 +26,8 @@ class LevyWalkConfig(ContinuousTimeRandomWalkConfig):
         Args:
             speed (float): A constant speed.
             exponent (float): The positive scaling exponent `b` of pareto distribution
-                in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pareto.html.
+                in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pareto.html
+                or https://jax.readthedocs.io/en/latest/_autosummary/jax.random.pareto.html.
         """
 
         super(LevyWalkConfig, self).__init__(**kwargs)
@@ -41,6 +47,43 @@ class LevyWalk(ContinuousTimeRandomWalk):
     def one_step(self) -> ConstType:
         return self.speed * self.generate_info["dt"]
 
+    def generate(
+        self,
+        realization: int = 10,
+        length: int = 1000,
+        dimension: int = 2,
+        dt: float = 1.0,
+        **generate_kwargs,
+    ) -> Ensemble:
+        ens = super().generate(realization, length, dimension, dt, **generate_kwargs)
+        realization, length, dimension, _ = list(self.generate_info.values())[:4]
+        interarrival: Dict[int, Array] = ens.meta["interarrival"]
+
+        u = self.get_orientation_steps(realization, capacity=length)
+        u = self.repeat(
+            u, interarrival, cutoff=length - 1  # realization x (length - 1) x -1
+        )
+        x = self._get_microstate_from_orientation(u)
+        ens.update_microstate(microstate=x)
+        return ens
+
+    def get_interarrival_times(self) -> Dict[int, Array]:
+        realization, length, _, _ = self.generate_info.values()
+
+        generator = partial(jax.random.pareto, b=self.exponent)
+        keys = jax.random.split(PRNGKey(randint(0, 1e9)), num=realization)
+        vmap_fn = vmap(self._get_interarrival_times_per_tracer, (None, 0))
+        taus, cutoffs = vmap_fn(generator, keys)
+
+        interarrival = {}
+        for id, (tau, cutoff) in enumerate(zip(taus, cutoffs, strict=True)):
+            if cutoff > 0:
+                arr = tau[:cutoff]
+                interarrival[id] = jnp.append(arr, length - jnp.sum(arr))
+            else:
+                interarrival[id] = jnp.array([length], dtype=int)
+        return interarrival
+
     def get_time_steps(self) -> Array:
         realization, length, _, dt = self.generate_info.values()
 
@@ -53,5 +96,10 @@ class LevyWalk(ContinuousTimeRandomWalk):
             shape=(-1, realization),
         )
         tau = jnp.array(jnp.round(tau, -int(jnp.log10(dt))) / dt)  # countable
+        if jnp.any(jnp.isinf(tau)):
+            raise ValueError(
+                f"`tau` contains infinite values for exponent={self.exponent}"
+            )
+
         tau = self.slice(arr=tau.astype(int), threshold=length - 1).T
         return tau

--- a/pydiffuser/models/mips.py
+++ b/pydiffuser/models/mips.py
@@ -131,8 +131,6 @@ class PhaseSeparation(ActiveOUParticle):
         x = jnp.concatenate((x, jnp.transpose(stx, (1, 0, 2))), axis=1)
 
         ens.update_microstate(microstate=x)
-        for id in range(realization):
-            ens[id].update_meta_dict(item={"diameter": sigma[id]})
         ens.update_meta_dict(item={"diameter": sigma})
         return ens
 

--- a/pydiffuser/models/rtp.py
+++ b/pydiffuser/models/rtp.py
@@ -1,7 +1,11 @@
 from functools import partial
+from typing import Dict
 
+import jax
 import jax.numpy as jnp
-from jax import Array
+from jax import Array, vmap
+from jax.random import PRNGKey
+from numpy.random import randint
 from scipy.stats import expon
 
 from pydiffuser.logger import logger
@@ -9,8 +13,9 @@ from pydiffuser.models.core import (
     ContinuousTimeRandomWalk,
     ContinuousTimeRandomWalkConfig,
 )
+from pydiffuser.tracer import Ensemble
 from pydiffuser.typing import ConstType
-from pydiffuser.utils import jitted
+from pydiffuser.utils import jitted, random
 
 
 class RunAndTumbleParticleConfig(ContinuousTimeRandomWalkConfig):
@@ -47,10 +52,47 @@ class RunAndTumbleParticle(ContinuousTimeRandomWalk):
             logger.warning("The precision is significantly low.", stacklevel=2)
         return
 
+    def generate(
+        self,
+        realization: int = 10,
+        length: int = 1000,
+        dimension: int = 2,
+        dt: float = 1.0,
+        **generate_kwargs,
+    ) -> Ensemble:
+        ens = super().generate(realization, length, dimension, dt, **generate_kwargs)
+        realization, length, dimension, _ = list(self.generate_info.values())[:4]
+        interarrival: Dict[int, Array] = ens.meta["interarrival"]
+
+        u = self.get_orientation_steps(realization, capacity=length)
+        u = self.repeat(
+            u, interarrival, cutoff=length - 1  # realization x (length - 1) x -1
+        )
+        x = self._get_microstate_from_orientation(u)
+        ens.update_microstate(microstate=x)
+        return ens
+
+    def get_interarrival_times(self) -> Dict[int, Array]:
+        realization, length, _, _ = self.generate_info.values()
+
+        generator = partial(random.exponential, scale=self.tc)
+        keys = jax.random.split(PRNGKey(randint(0, 1e9)), num=realization)
+        vmap_fn = vmap(self._get_interarrival_times_per_tracer, (None, 0))
+        taus, cutoffs = vmap_fn(generator, keys)
+
+        interarrival = {}
+        for id, (tau, cutoff) in enumerate(zip(taus, cutoffs, strict=True)):
+            if cutoff > 0:
+                arr = tau[:cutoff]
+                interarrival[id] = jnp.append(arr, length - jnp.sum(arr))
+            else:
+                interarrival[id] = jnp.array([length], dtype=int)
+        return interarrival
+
     def get_time_steps(self) -> Array:
         realization, length, _, dt = self.generate_info.values()
 
-        num_runs = int(length / self.tc * 2) if self.rate < 1 else length  # TODO
+        num_runs = int(length / self.tc * 2) if self.rate < 1 else length
         tau = jitted.get_noise(
             generator=partial(expon.rvs, scale=self.tc),
             size=realization * num_runs,

--- a/pydiffuser/models/vicsek.py
+++ b/pydiffuser/models/vicsek.py
@@ -128,8 +128,6 @@ class VicsekModel(OverdampedLangevin):
         x = jnp.concatenate((x, jnp.transpose(stx_x, (1, 0, 2))), axis=1)
 
         ens.update_microstate(microstate=x)
-        for id in range(realization):
-            ens[id].update_meta_dict(item={"direction": phi[id]})
         ens.update_meta_dict(item={"direction": phi})
         return ens
 

--- a/pydiffuser/utils/helpers.py
+++ b/pydiffuser/utils/helpers.py
@@ -1,4 +1,5 @@
 import functools
+import warnings
 from dataclasses import dataclass
 from typing import Callable, Optional
 
@@ -54,3 +55,16 @@ def checktime(nonzero: bool = False) -> Callable[[Callable[P, T]], Callable[P, T
         return wrapper
 
     return decorator
+
+
+def deprecated(fn: Callable[P, T]) -> Callable[P, T]:
+    @functools.wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        warnings.warn(
+            f"The callable `{fn.__name__}` in `{fn.__module__}` is deprecated.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/pydiffuser/utils/random.py
+++ b/pydiffuser/utils/random.py
@@ -1,0 +1,16 @@
+from collections.abc import Sequence
+from functools import partial
+
+from jax import Array, jit, lax, random
+from jax._src.typing import ArrayLike, DTypeLike
+
+
+@partial(jit, static_argnums=(2, 3))
+def exponential(
+    key: ArrayLike,
+    scale: ArrayLike,
+    shape: Sequence[int] = (),
+    dtype: DTypeLike = float,
+) -> Array:
+    scale = lax.convert_element_type(scale, dtype)
+    return lax.mul(random.exponential(key, shape, dtype), scale)

--- a/tests/utils/test_jitted.py
+++ b/tests/utils/test_jitted.py
@@ -3,9 +3,11 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 import pytest
+from jax.random import PRNGKey
 from numpy.random import rand, randint, uniform
 from scipy.stats import expon, norm, pareto
 
+import pydiffuser as pyd
 from pydiffuser.utils.jitted import get_noise, normalize
 
 
@@ -31,10 +33,11 @@ def test_normalize():
         partial(expon.rvs, scale=10),
         norm.rvs,
         partial(pareto.rvs, b=1.5),
-        jax.random.uniform,
-        jax.random.exponential,
-        jax.random.normal,
-        partial(jax.random.pareto, b=1.5),
+        partial(jax.random.uniform, key=PRNGKey(42)),
+        partial(jax.random.normal, key=PRNGKey(42)),
+        partial(jax.random.pareto, key=PRNGKey(42), b=1.5),
+        partial(jax.random.exponential, key=PRNGKey(42)),
+        partial(pyd.random.exponential, key=PRNGKey(42), scale=10),
     ],
 )
 def test_get_noise(generator):


### PR DESCRIPTION
- Alter the CTRW strategy to generate `Ensemble`.
    - See `levy` and `rtp`.
- `self.precision_x64 = True` is automatically set to use `int64`.